### PR TITLE
add support for alt update branch name if repo var set

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -56,6 +56,10 @@ runs:
             export PATH="${HOME}/.platformsh/bin:${PATH}"
           fi
           
+          if [[ '' != ${{ vars.PSH_SOP_UPDATE_BRANCH }} ]]; then
+            export PSH_SOP_UPDATE_BRANCH="${{ vars.PSH_SOP_UPDATE_BRANCH }}"
+          fi
+          
           printf "Beginning Source Operations toolkit install...\n"
 
           curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 trigger-sopupdate; } 3<&0


### PR DESCRIPTION
exports PSH_SOP_UPDATE_BRANCH if set as a repo var before triggering a source operation update