### PR TITLE
refactor previous attempt to add support for alt update branch name

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -56,6 +56,10 @@ runs:
             export PATH="${HOME}/.platformsh/bin:${PATH}"
           fi
           
+          if [[ '' != "${{ vars.PSH_SOP_UPDATE_BRANCH }}" ]]; then
+            export PSH_SOP_UPDATE_BRANCH="${{ vars.PSH_SOP_UPDATE_BRANCH }}"
+          fi
+          
           printf "Beginning Source Operations toolkit install...\n"
 
           curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 trigger-sopupdate; } 3<&0


### PR DESCRIPTION
if a repo variable has been set for an alternate update branch name, export the env before we call the source op toolkit