### PR TITLE
Revert "refactor previous attempt to add support for alt update branch name"

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -56,10 +56,6 @@ runs:
             export PATH="${HOME}/.platformsh/bin:${PATH}"
           fi
           
-          if [[ '' != "${{ vars.PSH_SOP_UPDATE_BRANCH }}" ]]; then
-            export PSH_SOP_UPDATE_BRANCH="${{ vars.PSH_SOP_UPDATE_BRANCH }}"
-          fi
-          
           printf "Beginning Source Operations toolkit install...\n"
 
           curl -fsS https://raw.githubusercontent.com/platformsh/source-operations/main/setup.sh | { bash /dev/fd/3 trigger-sopupdate; } 3<&0


### PR DESCRIPTION
Reverts platformsh/gha-run-sourceops-update#3

argh!

```
Error: platformsh/gha-run-sourceops-update/main/action.yaml (Line: 53, Col: 14): Unrecognized named-value: 'vars'. Located at position 1 within expression: vars.PSH_SOP_UPDATE_BRANCH
Error: GitHub.DistributedTask.ObjectTemplating.TemplateValidationException: The template is not valid. platformsh/gha-run-sourceops-update/main/action.yaml (Line: 53, Col: 14): Unrecognized named-value: 'vars'. Located at position 1 within expression: vars.PSH_SOP_UPDATE_BRANCH
```