### PR TITLE
Adds support for alt update branch name

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -7,6 +7,10 @@ inputs:
   platformsh_token:
     description: 'Platform.sh API Token. Needed to trigger the source operation.'
     required: true
+  update_branch_name:
+    description: 'Name of the branch where you want to run the updates. Defaults to "update"'
+    required: false
+    default: ''
 
 #env:
 #  PLATFORMSH_CLI_TOKEN: ${{ secrets.TEMPLATES_CLI_TOKEN }}
@@ -56,8 +60,9 @@ runs:
             export PATH="${HOME}/.platformsh/bin:${PATH}"
           fi
           
-          if [[ '' != "${{ vars.PSH_SOP_UPDATE_BRANCH }}" ]]; then
-            export PSH_SOP_UPDATE_BRANCH="${{ vars.PSH_SOP_UPDATE_BRANCH }}"
+          if [[ '' != "${{ inputs.update_branch_name }}" ]]; then
+            echo "Alternate update branch name requested. Changing..."
+            export PSH_SOP_UPDATE_BRANCH="${{ inputs.update_branch_name }}"
           fi
           
           printf "Beginning Source Operations toolkit install...\n"


### PR DESCRIPTION
- adds input for alternate branch name. Defaults to empty
- if alt branch input isnt empty, sets the needed environment vars for the toolkit.